### PR TITLE
Implement mods for elemental magic recast and blue magic recast

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -538,11 +538,11 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
     if attacker:getMainJob() == xi.job.THF then
         -- Add DEX/AGI bonus to first hit if THF main and valid Sneak/Trick Attack
         if calcParams.sneakApplicable then
-            finaldmg = finaldmg + calcParams.pdif * attacker:getStat(xi.mod.DEX) * (1 + attacker:getMod(xi.mod.SNEAK_ATK_DEX) / 100) * (1 + attacker:getMod(xi.mod.AUGMENTS_SA) / 100)
+            finaldmg = (finaldmg + calcParams.pdif * attacker:getStat(xi.mod.DEX) * (1 + attacker:getMod(xi.mod.SNEAK_ATK_DEX) / 100)) * (1 + attacker:getMod(xi.mod.AUGMENTS_SA) / 100)
         end
 
         if calcParams.trickApplicable then
-            finaldmg = finaldmg + calcParams.pdif * attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI) / 100) * (1 + attacker:getMod(xi.mod.AUGMENTS_TA) / 100)
+            finaldmg = (finaldmg + calcParams.pdif * attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI) / 100)) * (1 + attacker:getMod(xi.mod.AUGMENTS_TA) / 100)
         end
     end
 

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -536,14 +536,25 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     -- Have to calculate added bonus for SA/TA here since it is done outside of the fTP multiplier
     if attacker:getMainJob() == xi.job.THF then
-        -- Add DEX/AGI bonus to first hit if THF main and valid Sneak/Trick Attack
+        -- Add DEX/AGI bonus to base damage of first hit if THF main and valid Sneak/Trick Attack
         if calcParams.sneakApplicable then
-            finaldmg = (finaldmg + calcParams.pdif * attacker:getStat(xi.mod.DEX) * (1 + attacker:getMod(xi.mod.SNEAK_ATK_DEX) / 100)) * (1 + attacker:getMod(xi.mod.AUGMENTS_SA) / 100)
+            local dexFactor = math.floor(attacker:getStat(xi.mod.DEX) * (1 + attacker:getMod(xi.mod.SNEAK_ATK_DEX) / 100))
+            finaldmg = math.floor(finaldmg + calcParams.pdif * dexFactor)
         end
 
         if calcParams.trickApplicable then
-            finaldmg = (finaldmg + calcParams.pdif * attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI) / 100)) * (1 + attacker:getMod(xi.mod.AUGMENTS_TA) / 100)
+            local agiFactor = math.floor(attacker:getStat(xi.mod.AGI) * (1 + attacker:getMod(xi.mod.TRICK_ATK_AGI) / 100))
+            finaldmg = math.floor(finaldmg + calcParams.pdif * agiFactor)
         end
+    end
+
+    -- these are deliberately left outside of the "If main job is THF" if-statement
+    if calcParams.sneakApplicable then
+        finaldmg = math.floor(finaldmg * (1 + attacker:getMod(xi.mod.AUGMENTS_SA) / 100))
+    end
+
+    if calcParams.trickApplicable then
+        finaldmg = math.floor(finaldmg * (1 + attacker:getMod(xi.mod.AUGMENTS_TA) / 100))
     end
 
     -- We've now accounted for any crit from SA/TA, so nullify them


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds and implements the ELEMENTAL_MAGIC_RECAST and BLUE_MAGIC_RECAST mods. These mods work as percentages, reducing the recast by x%.

Ancillary changes:

* The PR also adds all item modifiers to Tutyr Sabots, one of the elemental magic recast items, and corrects the mod type of the "skillchain bonus" on another ele recast item, the Amalric Slops and +1 version.
* Fixed the magic type of the blue magic spells Mind Blast, Mysterious Light, Regurgitation, and Sandspin. I noticed during testing that these all were using useBreathSpell instead of useMagicalSpell.

## Steps to test these changes

For blue magic: 

!changejob BLU 99
!additem 27082 (hashishin bazubands, blue magic recast -13%)

Cast a spell without the gear equipped, then with it equipped. You should see the recast go down by a factor of 0.97 (from 3% haste) * 0.87 (from BLUE_MAGIC_RECAST -13) = 0.844. So for example, when I do this test with the spell Regurgitation, the spell has a 24s recast without the gloves, but a 20s recast with the gloves. `floor(24*0.97*0.87) = 20`.

For elemental magic:

!changejob BLM 99
!additem 26905 (wicce coat +1, ele magic recast -14%)
!additem 27490 (tutyr sabots, ele magic recast -7%)

Each of these items also have haste 3%, so keep that in mind. So by equipping those two pieces, you should see recast go down by a factor of 0.94 (from 3+3% haste) * 0.79 (from 14+7% ele recast down) = 0.743. Sure enough, when I do this test with Flood II, I see a regular recast of 60 seconds, but when I put on the gear I see a recast of 44s. `floor(60*0.743) = 44`.
